### PR TITLE
Changing the master/slave jargon

### DIFF
--- a/jmespath/lexer.py
+++ b/jmespath/lexer.py
@@ -38,13 +38,13 @@ class Lexer(object):
     )
 
     def __init__(self):
-        self.master_regex = re.compile(self.TOKENS)
+        self.main_regex = re.compile(self.TOKENS)
 
     def tokenize(self, expression):
         if not expression:
             raise EmptyExpressionError()
         previous_column = 0
-        for match in self.master_regex.finditer(expression):
+        for match in self.main_regex.finditer(expression):
             value = match.group()
             start = match.start()
             end = match.end()

--- a/tccli/services/cdb/v20170320/help.py
+++ b/tccli/services/cdb/v20170320/help.py
@@ -170,7 +170,7 @@ INFO = {
       },
       {
         "name": "TaskTypes",
-        "desc": "Task type. If no value is passed in, all task types will be queried. Valid values:\n1 - rolling back a database;\n2 - performing an SQL operation;\n3 - importing data;\n5 - setting a parameter;\n6 - initializing a TencentDB instance;\n7 - restarting a TencentDB instance;\n8 - enabling GTID of a TencentDB instance;\n9 - upgrading a read-only instance;\n10 - rolling back databases in batches;\n11 - upgrading a master instance;\n12 - deleting a TencentDB table;\n13 - promoting a disaster recovery instance."
+        "desc": "Task type. If no value is passed in, all task types will be queried. Valid values:\n1 - rolling back a database;\n2 - performing an SQL operation;\n3 - importing data;\n5 - setting a parameter;\n6 - initializing a TencentDB instance;\n7 - restarting a TencentDB instance;\n8 - enabling GTID of a TencentDB instance;\n9 - upgrading a read-only instance;\n10 - rolling back databases in batches;\n11 - upgrading a main instance;\n12 - deleting a TencentDB table;\n13 - promoting a disaster recovery instance."
       },
       {
         "name": "TaskStatus",
@@ -386,7 +386,7 @@ INFO = {
         "desc": "Instance ID in the format of cdb-c1nl9rpv. It is the same as the instance ID displayed on the TencentDB Console page."
       }
     ],
-    "desc": "This API (SwitchForUpgrade) is used to switch to a new instance. You can initiate this process when the master instance being upgraded is pending switch."
+    "desc": "This API (SwitchForUpgrade) is used to switch to a new instance. You can initiate this process when the main instance being upgraded is pending switch."
   },
   "DeleteParamTemplate": {
     "params": [
@@ -458,16 +458,16 @@ INFO = {
         "desc": "AZ information. By default, the system will automatically select an AZ. Please use the [DescribeDBZoneConfig](https://cloud.tencent.com/document/api/236/17229) API to query the supported AZs."
       },
       {
-        "name": "MasterInstanceId",
-        "desc": "Instance ID, which is required and the same as the master instance ID when purchasing read-only or disaster recovery instances. Please use the [DescribeDBInstances](https://cloud.tencent.com/document/api/236/15872) API to query the instance IDs."
+        "name": "MainInstanceId",
+        "desc": "Instance ID, which is required and the same as the main instance ID when purchasing read-only or disaster recovery instances. Please use the [DescribeDBInstances](https://cloud.tencent.com/document/api/236/15872) API to query the instance IDs."
       },
       {
         "name": "InstanceRole",
-        "desc": "Instance type. Valid values: master (master instance), dr (disaster recovery instance), ro (read-only instance). Default value: master."
+        "desc": "Instance type. Valid values: main (main instance), dr (disaster recovery instance), ro (read-only instance). Default value: main."
       },
       {
-        "name": "MasterRegion",
-        "desc": "AZ information of the master instance, which is required for purchasing disaster recovery instances."
+        "name": "MainRegion",
+        "desc": "AZ information of the main instance, which is required for purchasing disaster recovery instances."
       },
       {
         "name": "Port",
@@ -475,7 +475,7 @@ INFO = {
       },
       {
         "name": "Password",
-        "desc": "Sets the root account password. Rule: the password can contain 8–64 characters and must contain at least two of the following types of characters: letters, digits, and special symbols (_+-&=!@#$%^*()). This parameter can be specified when purchasing master instances and is meaningless for read-only or disaster recovery instances."
+        "desc": "Sets the root account password. Rule: the password can contain 8–64 characters and must contain at least two of the following types of characters: letters, digits, and special symbols (_+-&=!@#$%^*()). This parameter can be specified when purchasing main instances and is meaningless for read-only or disaster recovery instances."
       },
       {
         "name": "ParamList",
@@ -483,19 +483,19 @@ INFO = {
       },
       {
         "name": "ProtectMode",
-        "desc": "Data replication mode. Valid values: 0 (async), 1 (semi-sync), 2 (strong sync). Default value: 0. This parameter can be specified when purchasing master instances and is meaningless for read-only or disaster recovery instances."
+        "desc": "Data replication mode. Valid values: 0 (async), 1 (semi-sync), 2 (strong sync). Default value: 0. This parameter can be specified when purchasing main instances and is meaningless for read-only or disaster recovery instances."
       },
       {
         "name": "DeployMode",
-        "desc": "Multi-AZ. Valid value: 0 (single-AZ), 1 (multi-AZ). Default value: 0. This parameter can be specified when purchasing master instances and is meaningless for read-only or disaster recovery instances."
+        "desc": "Multi-AZ. Valid value: 0 (single-AZ), 1 (multi-AZ). Default value: 0. This parameter can be specified when purchasing main instances and is meaningless for read-only or disaster recovery instances."
       },
       {
-        "name": "SlaveZone",
-        "desc": "AZ information of slave database 1, which is the `Zone` value by default. This parameter can be specified when purchasing master instances and is meaningless for read-only or disaster recovery instances."
+        "name": "SubordinateZone",
+        "desc": "AZ information of subordinate database 1, which is the `Zone` value by default. This parameter can be specified when purchasing main instances and is meaningless for read-only or disaster recovery instances."
       },
       {
         "name": "BackupZone",
-        "desc": "AZ information of slave database 2, which is empty by default. This parameter can be specified when purchasing strong sync master instances and is meaningless for other types of instances."
+        "desc": "AZ information of subordinate database 2, which is empty by default. This parameter can be specified when purchasing strong sync main instances and is meaningless for other types of instances."
       },
       {
         "name": "SecurityGroup",
@@ -530,7 +530,7 @@ INFO = {
         "desc": "Instance type. Valid values: HA (High-Availability Edition), BASIC (Basic Edition). If this parameter is not specified, High-Availability Edition will be used by default."
       }
     ],
-    "desc": "This API is used to create a pay-as-you-go TencentDB instance (which can be a master, disaster recovery, or read-only instance) by passing in information such as instance specifications, MySQL version number, and quantity.\n\nThis is an async API. You can also use the [DescribeDBInstances](https://cloud.tencent.com/document/api/236/15872) API to query the instance details. If the `Status` value of an instance is 1 and `TaskStatus` is 0, the instance has been successfully delivered.\n\n1. Please use the [DescribeDBZoneConfig](https://cloud.tencent.com/document/api/236/17229) API to query the supported instance specifications first and then use the [DescribeDBPrice](https://cloud.tencent.com/document/api/236/18566) API to query the prices of the supported instances;\n2. You can create up to 100 instances at a time, with an instance validity period of up to 36 months;\n3. MySQL v5.5, v5.6, and v5.7 are supported;\n4. Master instances, read-only instances, and disaster recovery instances can be created;\n5. If `Port`, `ParamList`, or `Password` is set in the input parameters, the instance will be initialized."
+    "desc": "This API is used to create a pay-as-you-go TencentDB instance (which can be a main, disaster recovery, or read-only instance) by passing in information such as instance specifications, MySQL version number, and quantity.\n\nThis is an async API. You can also use the [DescribeDBInstances](https://cloud.tencent.com/document/api/236/15872) API to query the instance details. If the `Status` value of an instance is 1 and `TaskStatus` is 0, the instance has been successfully delivered.\n\n1. Please use the [DescribeDBZoneConfig](https://cloud.tencent.com/document/api/236/17229) API to query the supported instance specifications first and then use the [DescribeDBPrice](https://cloud.tencent.com/document/api/236/18566) API to query the prices of the supported instances;\n2. You can create up to 100 instances at a time, with an instance validity period of up to 36 months;\n3. MySQL v5.5, v5.6, and v5.7 are supported;\n4. Main instances, read-only instances, and disaster recovery instances can be created;\n5. If `Port`, `ParamList`, or `Password` is set in the input parameters, the instance will be initialized."
   },
   "AddTimeWindow": {
     "params": [
@@ -768,14 +768,14 @@ INFO = {
       },
       {
         "name": "EngineVersion",
-        "desc": "Version of master instance database engine. Value range: 5.6, 5.7"
+        "desc": "Version of main instance database engine. Value range: 5.6, 5.7"
       },
       {
         "name": "WaitSwitch",
         "desc": "Mode of switch to a new instance. Value range: 0 (switch immediately), 1 (switch within a time window). Default value: 0. If the value is 1, the switch process will be performed within a time window. Or, you can call the [switching to new instance API](https://cloud.tencent.com/document/product/236/15864) to trigger the process."
       }
     ],
-    "desc": "This API (UpgradeDBInstanceEngineVersion) is used to upgrade the version of a TencentDB instance, which can be a master instance, disaster recovery instance, or read-only instance."
+    "desc": "This API (UpgradeDBInstanceEngineVersion) is used to upgrade the version of a TencentDB instance, which can be a main instance, disaster recovery instance, or read-only instance."
   },
   "DescribeInstanceParamRecords": {
     "params": [
@@ -928,7 +928,7 @@ INFO = {
       },
       {
         "name": "InstanceTypes",
-        "desc": "Instance type. Value range: 1 (master), 2 (disaster recovery), 3 (read-only)."
+        "desc": "Instance type. Value range: 1 (main), 2 (disaster recovery), 3 (read-only)."
       },
       {
         "name": "Vips",
@@ -960,7 +960,7 @@ INFO = {
       },
       {
         "name": "TaskStatus",
-        "desc": "Instance task status. Value range: <br>0 - no task <br>1 - upgrading <br>2 - importing data <br>3 - activating slave <br>4 - public network access enabled <br>5 - batch operation in progress <br>6 - rolling back <br>7 - public network access not enabled <br>8 - modifying password <br>9 - renaming instance <br>10 - restarting <br>12 - migrating self-built instance <br>13 - dropping table <br>14 - creating and syncing disaster recovery instance <br>15 - pending upgrade and switch <br>16 - upgrade and switch in progress <br>17 - upgrade and switch completed"
+        "desc": "Instance task status. Value range: <br>0 - no task <br>1 - upgrading <br>2 - importing data <br>3 - activating subordinate <br>4 - public network access enabled <br>5 - batch operation in progress <br>6 - rolling back <br>7 - public network access not enabled <br>8 - modifying password <br>9 - renaming instance <br>10 - restarting <br>12 - migrating self-built instance <br>13 - dropping table <br>14 - creating and syncing disaster recovery instance <br>15 - pending upgrade and switch <br>16 - upgrade and switch in progress <br>17 - upgrade and switch completed"
       },
       {
         "name": "EngineVersions",
@@ -1012,22 +1012,22 @@ INFO = {
       },
       {
         "name": "WithDr",
-        "desc": "Whether instances corresponding to the disaster recovery relationship are included. Valid values: 0 (not included), 1 (included). Default value: 1. If a master instance is pulled, the data of the disaster recovery relationship will be in the `DrInfo` field. If a disaster recovery instance is pulled, the data of the disaster recovery relationship will be in the `MasterInfo` field. The disaster recovery relationship contains only partial basic data. To get the detailed data, you need to call an API to pull it."
+        "desc": "Whether instances corresponding to the disaster recovery relationship are included. Valid values: 0 (not included), 1 (included). Default value: 1. If a main instance is pulled, the data of the disaster recovery relationship will be in the `DrInfo` field. If a disaster recovery instance is pulled, the data of the disaster recovery relationship will be in the `MainInfo` field. The disaster recovery relationship contains only partial basic data. To get the detailed data, you need to call an API to pull it."
       },
       {
         "name": "WithRo",
         "desc": "Whether read-only instances are included. Valid values: 0 (not included), 1 (included). Default value: 1."
       },
       {
-        "name": "WithMaster",
-        "desc": "Whether master instances are included. Valid values: 0 (not included), 1 (included). Default value: 1."
+        "name": "WithMain",
+        "desc": "Whether main instances are included. Valid values: 0 (not included), 1 (included). Default value: 1."
       },
       {
         "name": "DeployGroupIds",
         "desc": "Placement group ID list."
       }
     ],
-    "desc": "This API (DescribeDBInstances) is used to query the list of TencentDB instances (which can be master, disaster recovery, or read-only instances). It supports filtering instances by project ID, instance ID, access address, and instance status."
+    "desc": "This API (DescribeDBInstances) is used to query the list of TencentDB instances (which can be main, disaster recovery, or read-only instances). It supports filtering instances by project ID, instance ID, access address, and instance status."
   },
   "ModifyRoGroupInfo": {
     "params": [
@@ -1196,7 +1196,7 @@ INFO = {
         "desc": "Array of instance IDs in the format of cdb-c1nl9rpv. It is the same as the instance ID displayed on the TencentDB Console page."
       }
     ],
-    "desc": "This API (RestartDBInstances) is used to restart TencentDB instances.\n\nNote:\n1. This API only supports restarting master instances.\n2. The instance status must be normal, and no other async tasks are in progress."
+    "desc": "This API (RestartDBInstances) is used to restart TencentDB instances.\n\nNote:\n1. This API only supports restarting main instances.\n2. The instance status must be normal, and no other async tasks are in progress."
   },
   "ModifyAccountPassword": {
     "params": [
@@ -1482,19 +1482,19 @@ INFO = {
       },
       {
         "name": "ProtectMode",
-        "desc": "Data replication mode. Valid values: 0 (async), 1 (semi-sync), 2 (strong sync). This parameter can be specified when upgrading master instances and is meaningless for read-only or disaster recovery instances."
+        "desc": "Data replication mode. Valid values: 0 (async), 1 (semi-sync), 2 (strong sync). This parameter can be specified when upgrading main instances and is meaningless for read-only or disaster recovery instances."
       },
       {
         "name": "DeployMode",
-        "desc": "Deployment mode. Valid values: 0 (single-AZ), 1 (multi-AZ). Default value: 0. This parameter can be specified when upgrading master instances and is meaningless for read-only or disaster recovery instances."
+        "desc": "Deployment mode. Valid values: 0 (single-AZ), 1 (multi-AZ). Default value: 0. This parameter can be specified when upgrading main instances and is meaningless for read-only or disaster recovery instances."
       },
       {
-        "name": "SlaveZone",
-        "desc": "AZ information of slave database 1, which is the `Zone` value of the instance by default. This parameter can be specified when upgrading master instances in multi-AZ mode and is meaningless for read-only or disaster recovery instances. You can use the [DescribeDBZoneConfig](https://cloud.tencent.com/document/product/236/17229) API to query the supported AZs."
+        "name": "SubordinateZone",
+        "desc": "AZ information of subordinate database 1, which is the `Zone` value of the instance by default. This parameter can be specified when upgrading main instances in multi-AZ mode and is meaningless for read-only or disaster recovery instances. You can use the [DescribeDBZoneConfig](https://cloud.tencent.com/document/product/236/17229) API to query the supported AZs."
       },
       {
         "name": "EngineVersion",
-        "desc": "Version of master instance database engine. Valid values: 5.5, 5.6, 5.7."
+        "desc": "Version of main instance database engine. Valid values: 5.5, 5.6, 5.7."
       },
       {
         "name": "WaitSwitch",
@@ -1502,14 +1502,14 @@ INFO = {
       },
       {
         "name": "BackupZone",
-        "desc": "AZ information of slave database 2, which is empty by default. This parameter can be specified when upgrading master instances and is meaningless for read-only or disaster recovery instances."
+        "desc": "AZ information of subordinate database 2, which is empty by default. This parameter can be specified when upgrading main instances and is meaningless for read-only or disaster recovery instances."
       },
       {
         "name": "InstanceRole",
-        "desc": "Instance type. Valid values: master (master instance), dr (disaster recovery instance), ro (read-only instance). Default value: master."
+        "desc": "Instance type. Valid values: main (main instance), dr (disaster recovery instance), ro (read-only instance). Default value: main."
       }
     ],
-    "desc": "This API is used to upgrade or downgrade a TencentDB instance, which can be a master instance, disaster recovery instance, or read-only instance."
+    "desc": "This API is used to upgrade or downgrade a TencentDB instance, which can be a main instance, disaster recovery instance, or read-only instance."
   },
   "CreateDeployGroup": {
     "params": [

--- a/tccli/services/dcdb/v20180411/help.py
+++ b/tccli/services/dcdb/v20180411/help.py
@@ -315,7 +315,7 @@ INFO = {
       },
       {
         "name": "ReadOnly",
-        "desc": "Whether to create a read-only account. 0: no; 1: for the account's SQL requests, the slave will be used first, and if it is unavailable, the master will be used; 2: the slave will be used first, and if it is unavailable, the operation will fail; 3: only the slave will be read from."
+        "desc": "Whether to create a read-only account. 0: no; 1: for the account's SQL requests, the subordinate will be used first, and if it is unavailable, the main will be used; 2: the subordinate will be used first, and if it is unavailable, the operation will fail; 3: only the subordinate will be read from."
       },
       {
         "name": "Description",
@@ -323,7 +323,7 @@ INFO = {
       },
       {
         "name": "DelayThresh",
-        "desc": "If the slave delay exceeds the set value of this parameter, the slave will be deemed to have failed.\nIt is recommended that this parameter be set to a value greater than 10. This parameter takes effect when `ReadOnly` is 1 or 2."
+        "desc": "If the subordinate delay exceeds the set value of this parameter, the subordinate will be deemed to have failed.\nIt is recommended that this parameter be set to a value greater than 10. This parameter takes effect when `ReadOnly` is 1 or 2."
       }
     ],
     "desc": "This API is used to create a TencentDB account. Multiple accounts can be created for one instance. Accounts with the same username but different hosts are different accounts."

--- a/tccli/services/dts/v20180330/help.py
+++ b/tccli/services/dts/v20180330/help.py
@@ -174,7 +174,7 @@ INFO = {
     ],
     "desc": "This API is used to query the execution result of a task."
   },
-  "SwitchDrToMaster": {
+  "SwitchDrToMain": {
     "params": [
       {
         "name": "DstInfo",
@@ -185,7 +185,7 @@ INFO = {
         "desc": "Database type (such as MySQL)"
       }
     ],
-    "desc": "This API is used to promote a disaster recovery instance to a master instance, which will stop sync from the original master instance and end the master/slave relationship."
+    "desc": "This API is used to promote a disaster recovery instance to a main instance, which will stop sync from the original main instance and end the main/subordinate relationship."
   },
   "StopMigrateJob": {
     "params": [

--- a/tccli/services/emr/v20190103/help.py
+++ b/tccli/services/emr/v20190103/help.py
@@ -132,7 +132,7 @@ INFO = {
       },
       {
         "name": "NodeFlag",
-        "desc": "Node flag. Valid values:\n<li>all: gets the information of nodes in all types except TencentDB information.</li>\n<li>master: gets master node information.</li>\n<li>core: gets core node information.</li>\n<li>task: gets task node information.</li>\n<li>common: gets common node information.</li>\n<li>router: gets router node information.</li>\n<li>db: gets TencentDB information in normal status.</li>\nNote: only the above values are supported for the time being. Entering other values will cause errors."
+        "desc": "Node flag. Valid values:\n<li>all: gets the information of nodes in all types except TencentDB information.</li>\n<li>main: gets main node information.</li>\n<li>core: gets core node information.</li>\n<li>task: gets task node information.</li>\n<li>common: gets common node information.</li>\n<li>router: gets router node information.</li>\n<li>db: gets TencentDB information in normal status.</li>\nNote: only the above values are supported for the time being. Entering other values will cause errors."
       },
       {
         "name": "Offset",
@@ -241,8 +241,8 @@ INFO = {
         "desc": "Client token."
       },
       {
-        "name": "NeedMasterWan",
-        "desc": "Whether to enable public IP access for master node. Valid values:\n<li>NEED_MASTER_WAN: enables public IP for master node.</li>\n<li>NOT_NEED_MASTER_WAN: does not enable.</li>Public IP is enabled for master node by default."
+        "name": "NeedMainWan",
+        "desc": "Whether to enable public IP access for main node. Valid values:\n<li>NEED_MASTER_WAN: enables public IP for main node.</li>\n<li>NOT_NEED_MASTER_WAN: does not enable.</li>Public IP is enabled for main node by default."
       },
       {
         "name": "RemoteLoginAtCreate",

--- a/tccli/services/es/v20180416/help.py
+++ b/tccli/services/es/v20180416/help.py
@@ -134,20 +134,20 @@ INFO = {
         "desc": "List of voucher IDs (only one voucher can be specified at a time currently)"
       },
       {
-        "name": "EnableDedicatedMaster",
-        "desc": "This parameter has been disused. Please use `NodeInfoList`\nWhether to create a dedicated master node <li>true: yes </li><li>false: no </li>Default value: false"
+        "name": "EnableDedicatedMain",
+        "desc": "This parameter has been disused. Please use `NodeInfoList`\nWhether to create a dedicated main node <li>true: yes </li><li>false: no </li>Default value: false"
       },
       {
-        "name": "MasterNodeNum",
-        "desc": "This parameter has been disused. Please use `NodeInfoList`\nNumber of dedicated master nodes (only 3 and 5 are supported. This value must be passed in if `EnableDedicatedMaster` is `true`)"
+        "name": "MainNodeNum",
+        "desc": "This parameter has been disused. Please use `NodeInfoList`\nNumber of dedicated main nodes (only 3 and 5 are supported. This value must be passed in if `EnableDedicatedMain` is `true`)"
       },
       {
-        "name": "MasterNodeType",
-        "desc": "This parameter has been disused. Please use `NodeInfoList`\nDedicated master node type, which must be passed in if `EnableDedicatedMaster` is `true` <li>ES.S1.SMALL2: 1-core 2 GB</li><li>ES.S1.MEDIUM4: 2-core 4 GB</li><li>ES.S1.MEDIUM8: 2-core 8 GB</li><li>ES.S1.LARGE16: 4-core 16 GB</li><li>ES.S1.2XLARGE32: 8-core 32 GB</li><li>ES.S1.4XLARGE32: 16-core 32 GB</li><li>ES.S1.4XLARGE64: 16-core 64 GB</li>"
+        "name": "MainNodeType",
+        "desc": "This parameter has been disused. Please use `NodeInfoList`\nDedicated main node type, which must be passed in if `EnableDedicatedMain` is `true` <li>ES.S1.SMALL2: 1-core 2 GB</li><li>ES.S1.MEDIUM4: 2-core 4 GB</li><li>ES.S1.MEDIUM8: 2-core 8 GB</li><li>ES.S1.LARGE16: 4-core 16 GB</li><li>ES.S1.2XLARGE32: 8-core 32 GB</li><li>ES.S1.4XLARGE32: 16-core 32 GB</li><li>ES.S1.4XLARGE64: 16-core 64 GB</li>"
       },
       {
-        "name": "MasterNodeDiskSize",
-        "desc": "This parameter has been disused. Please use `NodeInfoList`\nDedicated master node disk size in GB, which is optional. If passed in, it can only be 50 and cannot be customized currently"
+        "name": "MainNodeDiskSize",
+        "desc": "This parameter has been disused. Please use `NodeInfoList`\nDedicated main node disk size in GB, which is optional. If passed in, it can only be 50 and cannot be customized currently"
       },
       {
         "name": "ClusterNameInConf",
@@ -269,16 +269,16 @@ INFO = {
         "desc": "This parameter has been disused. Please use `NodeInfoList`\nNode specification <li>ES.S1.SMALL2: 1-core 2 GB </li><li>ES.S1.MEDIUM4: 2-core 4 GB </li><li>ES.S1.MEDIUM8: 2-core 8 GB </li><li>ES.S1.LARGE16: 4-core 16 GB </li><li>ES.S1.2XLARGE32: 8-core 32 GB </li><li>ES.S1.4XLARGE32: 16-core 32 GB </li><li>ES.S1.4XLARGE64: 16-core 64 GB </li>"
       },
       {
-        "name": "MasterNodeNum",
-        "desc": "This parameter has been disused. Please use `NodeInfoList`\nNumber of dedicated master nodes (only 3 and 5 are supported)"
+        "name": "MainNodeNum",
+        "desc": "This parameter has been disused. Please use `NodeInfoList`\nNumber of dedicated main nodes (only 3 and 5 are supported)"
       },
       {
-        "name": "MasterNodeType",
-        "desc": "This parameter has been disused. Please use `NodeInfoList`\nDedicated master node specification <li>ES.S1.SMALL2: 1-core 2 GB</li><li>ES.S1.MEDIUM4: 2-core 4 GB</li><li>ES.S1.MEDIUM8: 2-core 8 GB</li><li>ES.S1.LARGE16: 4-core 16 GB</li><li>ES.S1.2XLARGE32: 8-core 32 GB</li><li>ES.S1.4XLARGE32: 16-core 32 GB</li><li>ES.S1.4XLARGE64: 16-core 64 GB</li>"
+        "name": "MainNodeType",
+        "desc": "This parameter has been disused. Please use `NodeInfoList`\nDedicated main node specification <li>ES.S1.SMALL2: 1-core 2 GB</li><li>ES.S1.MEDIUM4: 2-core 4 GB</li><li>ES.S1.MEDIUM8: 2-core 8 GB</li><li>ES.S1.LARGE16: 4-core 16 GB</li><li>ES.S1.2XLARGE32: 8-core 32 GB</li><li>ES.S1.4XLARGE32: 16-core 32 GB</li><li>ES.S1.4XLARGE64: 16-core 64 GB</li>"
       },
       {
-        "name": "MasterNodeDiskSize",
-        "desc": "This parameter has been disused. Please use `NodeInfoList`\nDedicated master node disk size in GB. This is 50 GB by default and currently cannot be customized"
+        "name": "MainNodeDiskSize",
+        "desc": "This parameter has been disused. Please use `NodeInfoList`\nDedicated main node disk size in GB. This is 50 GB by default and currently cannot be customized"
       },
       {
         "name": "ForceRestart",
@@ -317,7 +317,7 @@ INFO = {
         "desc": "Kibana private port"
       }
     ],
-    "desc": "This API is used for operations such as modifying node specification, renaming an instance, modifying configuration, resetting password, and setting Kibana blacklist/whitelist. `InstanceId` is required, while `ForceRestart` is optional. Other parameters or parameter combinations and their meanings are as follows:\n- InstanceName: renames an instance (only for instance identification)\n- NodeInfoList: modifies node configuration (horizontally scaling nodes, vertically scaling nodes, adding master nodes, adding cold nodes, etc.)\n- EsConfig: modifies cluster configuration\n- Password: changes the password of the default user \"elastic\"\n- EsAcl: modifies the ACL\n- CosBackUp: sets auto-backup to COS for a cluster\nOnly one of the parameters or parameter combinations above can be passed in at a time, while passing fewer or more ones will cause the request to fail."
+    "desc": "This API is used for operations such as modifying node specification, renaming an instance, modifying configuration, resetting password, and setting Kibana blacklist/whitelist. `InstanceId` is required, while `ForceRestart` is optional. Other parameters or parameter combinations and their meanings are as follows:\n- InstanceName: renames an instance (only for instance identification)\n- NodeInfoList: modifies node configuration (horizontally scaling nodes, vertically scaling nodes, adding main nodes, adding cold nodes, etc.)\n- EsConfig: modifies cluster configuration\n- Password: changes the password of the default user \"elastic\"\n- EsAcl: modifies the ACL\n- CosBackUp: sets auto-backup to COS for a cluster\nOnly one of the parameters or parameter combinations above can be passed in at a time, while passing fewer or more ones will cause the request to fail."
   },
   "DeleteInstance": {
     "params": [
@@ -349,7 +349,7 @@ INFO = {
       },
       {
         "name": "LogType",
-        "desc": "Log type. Default value: 1\n<li>1: master log</li>\n<li>2: search slow log</li>\n<li>3: index slow log</li>\n<li>4: GC log</li>"
+        "desc": "Log type. Default value: 1\n<li>1: main log</li>\n<li>2: search slow log</li>\n<li>3: index slow log</li>\n<li>4: GC log</li>"
       },
       {
         "name": "SearchKey",

--- a/tccli/services/gme/v20180711/help.py
+++ b/tccli/services/gme/v20180711/help.py
@@ -49,7 +49,7 @@ INFO = {
         "desc": "Application status. Valid values: open, close"
       }
     ],
-    "desc": "This API is used to change the status of an application's master switch."
+    "desc": "This API is used to change the status of an application's main switch."
   },
   "DescribeAppStatistics": {
     "params": [

--- a/tccli/services/kms/v20190118/help.py
+++ b/tccli/services/kms/v20190118/help.py
@@ -95,7 +95,7 @@ INFO = {
         "desc": "Unique CMK ID"
       }
     ],
-    "desc": "This API is used to disable a master key. The disabled key cannot be used for encryption and decryption operations."
+    "desc": "This API is used to disable a main key. The disabled key cannot be used for encryption and decryption operations."
   },
   "GenerateDataKey": {
     "params": [
@@ -267,7 +267,7 @@ INFO = {
         "desc": "Specifies the key type. Default value: 1. Valid value: 1 - default type, indicating that the CMK is created by KMS; 2 - EXTERNAL type, indicating that you need to import key material. For more information, please see the `GetParametersForImport` and `ImportKeyMaterial` API documents."
       }
     ],
-    "desc": "Create a master key CMK (Custom Master Key) for user management data keys"
+    "desc": "Create a main key CMK (Custom Main Key) for user management data keys"
   },
   "DescribeWhiteBoxKey": {
     "params": [
@@ -339,7 +339,7 @@ INFO = {
         "desc": "Filter by `KeyUsage` of CMKs. Valid values: `ALL` (filter all CMKs), `ENCRYPT_DECRYPT` (it will be used when the parameter is left empty), `ASYMMETRIC_DECRYPT_RSA_2048`, `ASYMMETRIC_DECRYPT_SM2`."
       }
     ],
-    "desc": "Get the master key list details according to the specified Offset and Limit."
+    "desc": "Get the main key list details according to the specified Offset and Limit."
   },
   "AsymmetricRsaDecrypt": {
     "params": [

--- a/tccli/services/mariadb/v20170312/help.py
+++ b/tccli/services/mariadb/v20170312/help.py
@@ -135,7 +135,7 @@ INFO = {
       },
       {
         "name": "MetricName",
-        "desc": "Name of pulled metric. Valid values: long_query, select_total, update_total, insert_total, delete_total, mem_hit_rate, disk_iops, conn_active, is_master_switched, slave_delay"
+        "desc": "Name of pulled metric. Valid values: long_query, select_total, update_total, insert_total, delete_total, mem_hit_rate, disk_iops, conn_active, is_main_switched, subordinate_delay"
       }
     ],
     "desc": "This API is used to view the instance performance data details."
@@ -362,7 +362,7 @@ INFO = {
       },
       {
         "name": "ReadOnly",
-        "desc": "Whether to create a read-only account. 0: no; 1: for the account's SQL requests, the slave will be used first, and if it is unavailable, the master will be used; 2: the slave will be used first, and if it is unavailable, the operation will fail."
+        "desc": "Whether to create a read-only account. 0: no; 1: for the account's SQL requests, the subordinate will be used first, and if it is unavailable, the main will be used; 2: the subordinate will be used first, and if it is unavailable, the operation will fail."
       },
       {
         "name": "Description",
@@ -370,7 +370,7 @@ INFO = {
       },
       {
         "name": "DelayThresh",
-        "desc": "Determines whether the slave is unavailable based on the passed-in time"
+        "desc": "Determines whether the subordinate is unavailable based on the passed-in time"
       }
     ],
     "desc": "This API is used to create a TencentDB account. Multiple accounts can be created for one instance. Accounts with the same username but different hosts are different accounts."
@@ -440,8 +440,8 @@ INFO = {
         "desc": "Sorting order. Valid values: desc, asc"
       },
       {
-        "name": "Slave",
-        "desc": "Whether to query slow queries of the slave. 0: master, 1: slave"
+        "name": "Subordinate",
+        "desc": "Whether to query slow queries of the subordinate. 0: main, 1: subordinate"
       }
     ],
     "desc": "This API is used to query the slow query log list."
@@ -555,7 +555,7 @@ INFO = {
       },
       {
         "name": "MetricName",
-        "desc": "Name of pulled metric. Valid values: long_query, select_total, update_total, insert_total, delete_total, mem_hit_rate, disk_iops, conn_active, is_master_switched, slave_delay"
+        "desc": "Name of pulled metric. Valid values: long_query, select_total, update_total, insert_total, delete_total, mem_hit_rate, disk_iops, conn_active, is_main_switched, subordinate_delay"
       }
     ],
     "desc": "This API is used to view the current performance data of a database instance."

--- a/tccli/services/mongodb/v20190725/help.py
+++ b/tccli/services/mongodb/v20190725/help.py
@@ -120,7 +120,7 @@ INFO = {
     "params": [
       {
         "name": "NodeNum",
-        "desc": "Number of nodes in each replica set. Currently, the number of nodes per replica set is fixed at 3, while the number of slave nodes per shard is customizable. For more information, please see the parameter returned by the `DescribeSpecInfo` API."
+        "desc": "Number of nodes in each replica set. Currently, the number of nodes per replica set is fixed at 3, while the number of subordinate nodes per shard is customizable. For more information, please see the parameter returned by the `DescribeSpecInfo` API."
       },
       {
         "name": "Memory",
@@ -288,7 +288,7 @@ INFO = {
       },
       {
         "name": "NodeNum",
-        "desc": "Number of nodes in each replica set. Currently, the number of nodes per replica set is fixed at 3, while the number of slave nodes per shard is customizable. For more information, please see the parameter returned by the `DescribeSpecInfo` API."
+        "desc": "Number of nodes in each replica set. Currently, the number of nodes per replica set is fixed at 3, while the number of subordinate nodes per shard is customizable. For more information, please see the parameter returned by the `DescribeSpecInfo` API."
       },
       {
         "name": "Memory",
@@ -433,7 +433,7 @@ INFO = {
         "desc": "Search keyword, which can be instance ID, instance name, or complete IP"
       }
     ],
-    "desc": "This API is used to query the list of TencentDB instances (which can be master, disaster recovery, or read-only instances). It supports filtering instances by project ID, instance ID, and instance status."
+    "desc": "This API is used to query the list of TencentDB instances (which can be main, disaster recovery, or read-only instances). It supports filtering instances by project ID, instance ID, and instance status."
   },
   "IsolateDBInstance": {
     "params": [

--- a/tccli/services/redis/v20180412/help.py
+++ b/tccli/services/redis/v20180412/help.py
@@ -43,7 +43,7 @@ INFO = {
       },
       {
         "name": "ReadonlyPolicy",
-        "desc": "Routing policy. Enter `master` for master node or `replication` for slave node"
+        "desc": "Routing policy. Enter `main` for main node or `replication` for subordinate node"
       },
       {
         "name": "Privilege",
@@ -76,7 +76,7 @@ INFO = {
       },
       {
         "name": "ReadonlyPolicy",
-        "desc": "Sub-account routing policy. Enter `master` to route to the master node or `slave` to route to the slave node"
+        "desc": "Sub-account routing policy. Enter `main` to route to the main node or `subordinate` to route to the subordinate node"
       },
       {
         "name": "Privilege",
@@ -298,7 +298,7 @@ INFO = {
       },
       {
         "name": "TypeVersion",
-        "desc": "Type edition. 1: standalone edition; 2: master-slave edition; 3: cluster edition"
+        "desc": "Type edition. 1: standalone edition; 2: main-subordinate edition; 3: cluster edition"
       },
       {
         "name": "EngineName",
@@ -314,7 +314,7 @@ INFO = {
       },
       {
         "name": "Type",
-        "desc": "Instance type. 1: legacy Redis Cluster Edition, 2: Redis 2.8 Master-Slave Edition, 3: CKV Master-Slave Edition, 4: CKV Cluster Edition, 5: Redis 2.8 Standalone Edition, 6: Redis 4.0 Master-Slave Edition, 7: Redis 4.0 Cluster Edition, 8: Redis 5.0 Master-Slave Edition, 9: Redis 5.0 Cluster Edition,"
+        "desc": "Instance type. 1: legacy Redis Cluster Edition, 2: Redis 2.8 Main-Subordinate Edition, 3: CKV Main-Subordinate Edition, 4: CKV Cluster Edition, 5: Redis 2.8 Standalone Edition, 6: Redis 4.0 Main-Subordinate Edition, 7: Redis 4.0 Cluster Edition, 8: Redis 5.0 Main-Subordinate Edition, 9: Redis 5.0 Cluster Edition,"
       },
       {
         "name": "SearchKeys",
@@ -434,8 +434,8 @@ INFO = {
         "desc": "Instance ID"
       },
       {
-        "name": "FilterSlave",
-        "desc": "Whether to filter out the slave node information"
+        "name": "FilterSubordinate",
+        "desc": "Whether to filter out the subordinate node information"
       }
     ],
     "desc": "This API is used to get the information of cluster edition instance shards."
@@ -466,7 +466,7 @@ INFO = {
       },
       {
         "name": "ReadonlyPolicy",
-        "desc": "Account routing policy. If `master` or `replication` is entered, it means to route to the master or slave node; if this is left blank, it means to write into the master node and read from the slave node by default"
+        "desc": "Account routing policy. If `main` or `replication` is entered, it means to route to the main or subordinate node; if this is left blank, it means to write into the main node and read from the subordinate node by default"
       }
     ],
     "desc": "This API is used to enable read/write separation."
@@ -598,11 +598,11 @@ INFO = {
       },
       {
         "name": "RedisShardNum",
-        "desc": "Number of shards. This parameter can be left blank for Redis 2.8 master-slave edition, CKV master-slave edition, and Redis 2.8 standalone edition"
+        "desc": "Number of shards. This parameter can be left blank for Redis 2.8 main-subordinate edition, CKV main-subordinate edition, and Redis 2.8 standalone edition"
       },
       {
         "name": "RedisReplicasNum",
-        "desc": "Number of replicas. This parameter can be left blank for Redis 2.8 master-slave edition, CKV master-slave edition, and Redis 2.8 standalone edition"
+        "desc": "Number of replicas. This parameter can be left blank for Redis 2.8 main-subordinate edition, CKV main-subordinate edition, and Redis 2.8 standalone edition"
       }
     ],
     "desc": "This API is used to upgrade an instance."
@@ -786,7 +786,7 @@ INFO = {
       },
       {
         "name": "ReplicasReadonly",
-        "desc": "Whether to support read-only replicas. Neither Redis 2.8 standard edition nor CKV standard edition supports read-only replicas. Read/write separation will be automatically enabled for an instance after it enables read-only replicas. Write requests will be directed to the master node and read requests will be distributed on slave nodes. To enable read-only replicas, we recommend you create 2 or more replicas."
+        "desc": "Whether to support read-only replicas. Neither Redis 2.8 standard edition nor CKV standard edition supports read-only replicas. Read/write separation will be automatically enabled for an instance after it enables read-only replicas. Write requests will be directed to the main node and read requests will be distributed on subordinate nodes. To enable read-only replicas, we recommend you create 2 or more replicas."
       },
       {
         "name": "InstanceName",

--- a/tccli/services/scf/v20180416/help.py
+++ b/tccli/services/scf/v20180416/help.py
@@ -26,7 +26,7 @@ INFO = {
       },
       {
         "name": "FunctionVersion",
-        "desc": "Master version of alias"
+        "desc": "Main version of alias"
       },
       {
         "name": "Namespace",
@@ -414,7 +414,7 @@ INFO = {
       },
       {
         "name": "FunctionVersion",
-        "desc": "Master version of alias"
+        "desc": "Main version of alias"
       },
       {
         "name": "Namespace",
@@ -429,7 +429,7 @@ INFO = {
         "desc": "Alias description"
       }
     ],
-    "desc": "This API is used to create an alias for a function version. You can use the alias to mark a specific function version such as DEV/RELEASE. You can also modify the version pointed to by the alias at any time.\nAn alias must point to a master version and can point to an additional version at the same time. If you specify an alias when invoking a function, the request will be sent to the versions pointed to by the alias. You can configure the ratio between the master version and additional version during request sending."
+    "desc": "This API is used to create an alias for a function version. You can use the alias to mark a specific function version such as DEV/RELEASE. You can also modify the version pointed to by the alias at any time.\nAn alias must point to a main version and can point to an additional version at the same time. If you specify an alias when invoking a function, the request will be sent to the versions pointed to by the alias. You can configure the ratio between the main version and additional version during request sending."
   },
   "ListVersionByFunction": {
     "params": [

--- a/tccli/services/sqlserver/v20180328/help.py
+++ b/tccli/services/sqlserver/v20180328/help.py
@@ -384,7 +384,7 @@ INFO = {
       },
       {
         "name": "Status",
-        "desc": "Instance status. Valid values:\n<li>1: applying</li>\n<li>2: running</li>\n<li>3: running restrictedly (master/slave switching)</li>\n<li>4: isolated</li>\n<li>5: repossessing</li>\n<li>6: repossessed</li>\n<li>7: executing task (e.g., backing up or rolling back instance)</li>\n<li>8: deactivated</li>\n<li>9: scaling out instance</li>\n<li>10: migrating instance</li>\n<li>11: read-only</li>\n<li>12: restarting</li>"
+        "desc": "Instance status. Valid values:\n<li>1: applying</li>\n<li>2: running</li>\n<li>3: running restrictedly (main/subordinate switching)</li>\n<li>4: isolated</li>\n<li>5: repossessing</li>\n<li>6: repossessed</li>\n<li>7: executing task (e.g., backing up or rolling back instance)</li>\n<li>8: deactivated</li>\n<li>9: scaling out instance</li>\n<li>10: migrating instance</li>\n<li>11: read-only</li>\n<li>12: restarting</li>"
       },
       {
         "name": "Offset",

--- a/tccli/services/vpc/v20170312/help.py
+++ b/tccli/services/vpc/v20170312/help.py
@@ -3093,7 +3093,7 @@ INFO = {
       },
       {
         "name": "DnsServers",
-        "desc": "DNS address. A maximum of 4 addresses is supported. The first one is master server by default, and the rest are slave servers."
+        "desc": "DNS address. A maximum of 4 addresses is supported. The first one is main server by default, and the rest are subordinate servers."
       },
       {
         "name": "DomainName",


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.