### PR TITLE
fix [TencentCloudSDKException] code:InvalidParameter message:The value type of parameter `InstanceIds` is not valid.

### DIFF
--- a/tccli/command.py
+++ b/tccli/command.py
@@ -186,7 +186,7 @@ class ActionCommand(BaseCommand):
     #     'Boolean': BooleanArgument
     # }
     ARG_TYPES = {
-
+        'Array': ListArgument
     }
     DEFAULT_ARG_CLASS = CLIArgument
 


### PR DESCRIPTION
ActionCommand add 'Array':ListArgument to ARG_TYPES struct,
 fix [TencentCloudSDKException] code:InvalidParameter message:The value type of parameter `InstanceIds` is not valid.