### PR TITLE
fix(loaders): handle self-referencing types to avoid infinite recursion

### DIFF
--- a/tccli/command.py
+++ b/tccli/command.py
@@ -371,9 +371,28 @@ class ActionCommand(BaseCommand):
                          % (token, prefix, type_name or "unknown"))
             seen_prefix.add((prefix, type_name))
         lines.append("")
-        lines.append("To pass deeper nested values, please use --cli-input-json "
-                     "'<full-request-json>' (run with --generate-cli-skeleton "
-                     "to get a JSON template).")
+        # Collect the top-level field names from each matched prefix so we
+        # can suggest a normal-mode alternative.
+        top_fields = []
+        seen_top = set()
+        for prefix, _type_name in seen_prefix:
+            top = prefix.split(".")[0] if prefix else ""
+            if top and top not in seen_top:
+                seen_top.add(top)
+                top_fields.append(top)
+        lines.append("To pass deeper nested values, choose either of the following:")
+        if top_fields:
+            sample_field = top_fields[0]
+            lines.append("  (1) Drop --cli-unfold-argument and pass the whole top-level "
+                         "field as a JSON string, e.g. --%s '{\"...\":{...}}' "
+                         "(applies to: %s)." % (sample_field, ", ".join(top_fields)))
+        else:
+            lines.append("  (1) Drop --cli-unfold-argument and pass the affected "
+                         "top-level field as a JSON string.")
+        lines.append("  (2) Use --cli-input-json file://<path/to/request.json> "
+                     "to provide the entire request as a JSON file "
+                     "(the value must begin with 'file://'; raw JSON strings are not accepted; "
+                     "run with --generate-cli-skeleton to get a JSON template).")
         return "\n".join(lines)
 
     def _get_profile(self, parsed_globals):

--- a/tccli/command.py
+++ b/tccli/command.py
@@ -279,8 +279,15 @@ class ActionCommand(BaseCommand):
         elif parsed_args.help:
             remaining.append(parsed_args.help)
         if remaining:
-            raise UnknownArgumentError(
-                "Unknown options: %s" % ', '.join(remaining))
+            # On unknown options, try to combine self-reference truncation
+            # information to produce a targeted hint, so that users do not
+            # only see the generic "Unknown options" when drilling into
+            # a self-referencing type path.
+            hint = self._build_recursive_hint(remaining)
+            msg = "Unknown options: %s" % ', '.join(remaining)
+            if hint:
+                msg += "\n\n" + hint
+            raise UnknownArgumentError(msg)
 
         if self._call_mode == Options_define.GenerateCliSkeleton:
             return self.generate_cli_skeleton_argument.generate_skeleton(parsed_globals)
@@ -306,6 +313,68 @@ class ActionCommand(BaseCommand):
                 value = parsed_args[name]
                 argument_object.add_to_params(action_params, value)
         return action_params
+
+    def _build_recursive_hint(self, remaining):
+        """
+        In --cli-unfold-argument mode, detect the case where the user drills
+        into a placeholder leaf truncated by self-reference cycle detection,
+        and produce a targeted hint.
+
+        Example: AllocationRuleExpression.Children is self-referencing, so
+        argument expansion only registers up to
+        `--RuleList.RuleDetail.Children.0`. If the user further passes
+        `--RuleList.RuleDetail.Children.0.RuleValue ...`, that argument falls
+        into `remaining` here. Instead of just raising the generic
+        "Unknown options", we tell the user which argument hit which
+        self-referencing type, and the recommended alternative usages.
+        """
+        # Only meaningful in --cli-unfold-argument mode
+        if self._call_mode != Options_define.CliUnfoldArgument:
+            return ""
+        try:
+            unfold_params = self._cli_data.get_unfold_param_info(
+                self._service_name, self._version, self._action_name,
+                profile=self.profile, param_array=True)
+        except Exception:
+            return ""
+
+        # Collect all leaf prefixes truncated by self-reference detection, e.g.
+        #   "RuleList.RuleDetail.Children.0" -> "AllocationRuleExpression"
+        truncated = {
+            name: info.get("recursive_type") or ""
+            for name, info in unfold_params.items()
+            if info.get("recursive_truncated")
+        }
+        if not truncated:
+            return ""
+
+        matched = OrderedDict()  # offending option -> (truncated prefix, self-referencing type name)
+        for token in remaining:
+            if not isinstance(token, str) or not token.startswith("--"):
+                continue
+            key = token[2:]
+            for prefix, type_name in truncated.items():
+                # Strict prefix match: "RuleList.RuleDetail.Children.0.RuleValue"
+                # should be matched by "RuleList.RuleDetail.Children.0".
+                if key.startswith(prefix + "."):
+                    matched[token] = (prefix, type_name)
+                    break
+
+        if not matched:
+            return ""
+
+        lines = ["Hint: the following option(s) drill into a self-referencing type "
+                 "that --cli-unfold-argument cannot expand further:"]
+        seen_prefix = set()
+        for token, (prefix, type_name) in matched.items():
+            lines.append("  %s  (under --%s, self-referencing type: %s)"
+                         % (token, prefix, type_name or "unknown"))
+            seen_prefix.add((prefix, type_name))
+        lines.append("")
+        lines.append("To pass deeper nested values, please use --cli-input-json "
+                     "'<full-request-json>' (run with --generate-cli-skeleton "
+                     "to get a JSON template).")
+        return "\n".join(lines)
 
     def _get_profile(self, parsed_globals):
         if getattr(parsed_globals, Options_define.Profile):

--- a/tccli/document_handler.py
+++ b/tccli/document_handler.py
@@ -175,6 +175,15 @@ class ActionDocumentHandler(BaseDocumentHandler):
                     self.doc.write('[%s ...]' % (param_info["members"]))
                 else:
                     self.doc.doc_description('[%s ...]' % (param_info["members"]))
+            elif isinstance(param_info["members"], str):
+                # Self-reference truncation placeholder: members is a type name string
+                # (e.g. "AllocationRuleExpression"). Render as a RecursiveRef placeholder
+                # and stop expanding further.
+                placeholder = '[<RecursiveRef:%s> ...]' % param_info["members"]
+                if self.doc.style.indentation > 2:
+                    self.doc.write(placeholder)
+                else:
+                    self.doc.doc_description(placeholder)
             else:
                 self.doc.write('[') if self.doc.style.indentation > 2 \
                     else self.doc.doc_description('[')
@@ -187,8 +196,14 @@ class ActionDocumentHandler(BaseDocumentHandler):
                 self.doc.style.new_line()
                 self.doc.doc_description(']')
         else:
-            if param_info["members"] not in BASE_TYPE:
-                self._handle_object_members(param_info["members"], param_info["type"])
+            if param_info["members"] in BASE_TYPE:
+                return
+            if isinstance(param_info["members"], str):
+                # Self-reference truncation placeholder (non-Array form): members is a
+                # type name string. Render as a RecursiveRef placeholder.
+                self.doc.doc_description('<RecursiveRef:%s>' % param_info["members"])
+                return
+            self._handle_object_members(param_info["members"], param_info["type"])
 
     def _handle_object_members(self, param_info, param_type):
         if param_type == "Array" or self.doc.style.indentation == 2:
@@ -216,6 +231,10 @@ class ActionDocumentHandler(BaseDocumentHandler):
     def _unfold_complex_object(self, param_info):
         if not param_info["type"] == "Array" and param_info["members"] in BASE_TYPE:
             return
+        # Self-reference truncation placeholder: non-Array with members as a type
+        # name string has nothing to expand, skip directly.
+        if not param_info["type"] == "Array" and isinstance(param_info["members"], str):
+            return
 
         self.doc.style.new_line()
         self.doc.doc_title('JSON Syntax')
@@ -232,13 +251,20 @@ class ActionDocumentHandler(BaseDocumentHandler):
     def _complex_object_doc(self, param_info, option):
         if param_info["members"] in BASE_TYPE:
             return
+        # Self-reference truncation placeholder: members is a type name string,
+        # no sub-members to iterate, return directly.
+        if not isinstance(param_info["members"], dict):
+            return
         self.doc.style.indent()
         for sub_param, sub_param_info in param_info["members"].items():
             self.doc.style.new_line()
             self._doc_title(option, sub_param, sub_param_info)
             self.doc.doc_description('%s' % sub_param_info["document"])
             self.doc.style.new_line()
-            if sub_param_info["members"] not in BASE_TYPE:
+            # Recurse only when the sub-member's members is still a dict (i.e. not
+            # truncated and not a base type).
+            if sub_param_info["members"] not in BASE_TYPE \
+                    and isinstance(sub_param_info["members"], dict):
                 self._complex_object_doc(sub_param_info, option)
         self.doc.style.dedent()
         self.doc.style.new_line()

--- a/tccli/loaders.py
+++ b/tccli/loaders.py
@@ -556,13 +556,20 @@ class Loader(object):
                 param_type = "Object"
                 type_name = recursive_type or "Object"
                 required = "Optional"
+                # Capture the top-level field name of this truncated leaf so we
+                # can suggest a normal-mode alternative (passing it as a JSON string).
+                top_field = param[0] if param else ""
                 document = (document or "") + \
                     ("\nNote: this field is a self-referencing type %s. "
                      "--cli-unfold-argument only expands the first level. "
-                     "For deeper nesting, please use --cli-input-json to provide "
-                     "the full request as JSON. "
-                     "You can run the command with --generate-cli-skeleton to get a JSON template."
-                     % (recursive_type or ""))
+                     "For deeper nesting you can choose either of the following:\n"
+                     "  (1) Drop --cli-unfold-argument and pass the whole top-level "
+                     "field --%s as a JSON string, e.g. --%s '{\"...\":{...}}'.\n"
+                     "  (2) Use --cli-input-json file://<path/to/request.json> to "
+                     "provide the entire request as a JSON file (the value must "
+                     "begin with 'file://'; raw JSON strings are not accepted).\n"
+                     "Run the command with --generate-cli-skeleton to get a JSON template."
+                     % (recursive_type or "", top_field, top_field))
 
             unfold_param[".".join(param)]["type"] = param_type
             unfold_param[".".join(param)]["type_name"] = type_name

--- a/tccli/loaders.py
+++ b/tccli/loaders.py
@@ -333,24 +333,43 @@ class Loader(object):
         param_info[para["name"]]["members"] = member
         return param_info
 
-    def _get_param_info(self, param_model, object_model):
+    def _get_param_info(self, param_model, object_model, visited=None, depth=0, max_depth=20):
+        # `visited` records compound types already expanded along the current DFS path,
+        # used to detect cycles caused by self/mutual references.
+        if visited is None:
+            visited = frozenset()
         param_info = {}
         for para in param_model:
+            member = para["member"]
+            # Hit a cycle or exceeded max depth: stop expanding and treat as a placeholder leaf.
+            recursive_hit = member not in BASE_TYPE and (member in visited or depth >= max_depth)
             if para["type"] == "list":
-                if para["member"] not in BASE_TYPE:
-                    self._filling_param_info(
-                        param_info, para, "list",
-                        [self._get_param_info(object_model[para["member"]]["members"], object_model)])
+                if member not in BASE_TYPE:
+                    if recursive_hit:
+                        self._filling_param_info(
+                            param_info, para, "list", [member])
+                    else:
+                        self._filling_param_info(
+                            param_info, para, "list",
+                            [self._get_param_info(
+                                object_model[member]["members"], object_model,
+                                visited | {member}, depth + 1, max_depth)])
                 else:
                     self._filling_param_info(
-                        param_info, para, "list", [para["member"]])
+                        param_info, para, "list", [member])
             else:
-                if para["member"] not in BASE_TYPE:
-                    param_info = self._filling_param_info(
-                        param_info, para, para["member"],
-                        self._get_param_info(object_model[para["member"]]["members"], object_model))
+                if member not in BASE_TYPE:
+                    if recursive_hit:
+                        param_info = self._filling_param_info(
+                            param_info, para, member, member)
+                    else:
+                        param_info = self._filling_param_info(
+                            param_info, para, member,
+                            self._get_param_info(
+                                object_model[member]["members"], object_model,
+                                visited | {member}, depth + 1, max_depth))
                 else:
-                    self._filling_param_info(param_info, para, para["member"], para["member"])
+                    self._filling_param_info(param_info, para, member, member)
         return param_info
 
     def get_param_info(self, service, version, action):
@@ -363,21 +382,39 @@ class Loader(object):
         param_model = service_model["objects"]
         return self._get_param_info(param_model[action + "Response"]["members"], param_model)
 
-    def _generate_param_skeleton(self, param_model, name):
+    def _generate_param_skeleton(self, param_model, name, visited=None, depth=0, max_depth=20):
+        # `visited` records compound types expanded along the path,
+        # used to detect infinite recursion from self-references.
+        if visited is None:
+            visited = frozenset()
         param_skeleton = {}
         for para in param_model:
+            member = para["member"]
+            recursive_hit = member not in BASE_TYPE and (member in visited or depth >= max_depth)
             if para["type"] == "list":
-                if para["member"] not in BASE_TYPE:
-                    param_skeleton[para["name"]] = \
-                        [self._generate_param_skeleton(name[para["member"]]["members"], name)]
+                if member not in BASE_TYPE:
+                    if recursive_hit:
+                        # Self-reference: use a placeholder string to indicate the value
+                        # should be passed as a whole JSON.
+                        param_skeleton[para["name"]] = ["RecursiveRef<%s>" % member]
+                    else:
+                        param_skeleton[para["name"]] = \
+                            [self._generate_param_skeleton(
+                                name[member]["members"], name,
+                                visited | {member}, depth + 1, max_depth)]
                 else:
-                    param_skeleton[para["name"]] = [PARAM_TYPE_MAP[para["member"]]]
+                    param_skeleton[para["name"]] = [PARAM_TYPE_MAP[member]]
             else:
-                if para["member"] not in BASE_TYPE:
-                    param_skeleton[para["name"]] = \
-                        self._generate_param_skeleton(name[para["member"]]["members"], name)
+                if member not in BASE_TYPE:
+                    if recursive_hit:
+                        param_skeleton[para["name"]] = "RecursiveRef<%s>" % member
+                    else:
+                        param_skeleton[para["name"]] = \
+                            self._generate_param_skeleton(
+                                name[member]["members"], name,
+                                visited | {member}, depth + 1, max_depth)
                 else:
-                    param_skeleton[para["name"]] = PARAM_TYPE_MAP[para["member"]]
+                    param_skeleton[para["name"]] = PARAM_TYPE_MAP[member]
         return param_skeleton
 
     def generate_param_skeleton(self, service, version, action):
@@ -396,7 +433,7 @@ class Loader(object):
         if param_array:
             all_param_list = self._add_array_item(all_param_list, profile)
 
-        return self._filling_unfold_param_info(all_param_list, service, version, action)
+        return self._filling_unfold_param_info(all_param_list, service, version, action, object_model)
 
     def _add_array_item(self, param_list, profile):
         is_conf_exist, conf_path = Utils.file_existed(os.path.join(os.path.expanduser("~"), ".tccli"),
@@ -415,19 +452,36 @@ class Loader(object):
                         all_param_list.append(tmp)
         return all_param_list
 
-    def _recur_get_unfold_param_info(self, param_model, object_model, return_param_list, param_list):
+    def _recur_get_unfold_param_info(self, param_model, object_model, return_param_list, param_list,
+                                     visited=None, depth=0, max_depth=20):
         for para in param_model:
-            self._get_unfold_param_info(object_model, return_param_list, param_list, para)
+            self._get_unfold_param_info(object_model, return_param_list, param_list, para,
+                                        visited, depth, max_depth)
         if param_list.pop().isdigit():
             param_list.pop()
 
-    def _get_unfold_param_info(self, object_model, return_param_list, param_list, para):
+    def _get_unfold_param_info(self, object_model, return_param_list, param_list, para,
+                               visited=None, depth=0, max_depth=20):
+        # `visited` is maintained along the path to detect self-referencing types
+        # (e.g. AllocationRuleExpression.Children).
+        if visited is None:
+            visited = frozenset()
         param_list.append(para["name"])
         if para["type"] == "list" and para["member"] not in BASE_TYPE:
             param_list.append('0')
-        if para["member"] not in BASE_TYPE:
-            self._recur_get_unfold_param_info(object_model[para["member"]]["members"],
-                                              object_model, return_param_list, param_list)
+        member = para["member"]
+        if member not in BASE_TYPE:
+            # Hit a cycle or exceeded max depth: register the current path as a
+            # placeholder leaf and stop expanding.
+            if member in visited or depth >= max_depth:
+                tmp = copy.deepcopy(param_list)
+                return_param_list.append(tmp)
+                if param_list.pop().isdigit():
+                    param_list.pop()
+                return
+            self._recur_get_unfold_param_info(object_model[member]["members"],
+                                              object_model, return_param_list, param_list,
+                                              visited | {member}, depth + 1, max_depth)
         else:
             tmp = copy.deepcopy(param_list)
             return_param_list.append(tmp)
@@ -435,7 +489,7 @@ class Loader(object):
             if param_list.pop().isdigit():
                 param_list.pop()
 
-    def _filling_unfold_param_info(self, param_list, service, version, action):
+    def _filling_unfold_param_info(self, param_list, service, version, action, object_model=None):
         unfold_param = {}
         param_info = self.get_param_info(service, version, action)
         for param in param_list:
@@ -448,12 +502,23 @@ class Loader(object):
             type_name = res["type_name"]
             required = res.get("required")
             document = res["document"]
+            recursive_truncated = False
+            recursive_type = None
 
             for idx, item in enumerate(tmp_param[1:]):
+                # Hit a self-reference truncation: current res["members"] is a
+                # placeholder string (type name) rather than a dict.
                 if res["type"] == "Array":
-                    res = res["members"][0][item]
+                    members_container = res["members"][0]
                 else:
-                    res = res["members"][item]
+                    members_container = res["members"]
+                if not isinstance(members_container, dict) or item not in members_container:
+                    # This leaf is a placeholder truncated by cycle detection; do not drill down further.
+                    recursive_truncated = True
+                    recursive_type = members_container if isinstance(members_container, str) \
+                        else (res.get("type_name") or "")
+                    break
+                res = members_container[item]
 
                 # ?? seriously ??
                 if required == "Required" and res["required"] == "Optional":
@@ -466,13 +531,49 @@ class Loader(object):
                     document = res["document"]
                     break
 
+            # Second check: after walking the path, see if this leaf itself is a compound
+            # type truncated by cycle detection (members is a placeholder).
+            if not recursive_truncated:
+                final_members = res.get("members")
+                if isinstance(final_members, list) and len(final_members) == 1 \
+                        and isinstance(final_members[0], str) \
+                        and final_members[0] not in BASE_TYPE \
+                        and final_members[0] not in CLI_BASE_TYPE:
+                    recursive_truncated = True
+                    recursive_type = final_members[0]
+                elif isinstance(final_members, str) \
+                        and final_members not in BASE_TYPE \
+                        and final_members not in CLI_BASE_TYPE:
+                    recursive_truncated = True
+                    recursive_type = final_members
+
             if len([item for item in param if item.isdigit() and int(item) > 0]) > 0:
                 required = "Optional"
+
+            if recursive_truncated:
+                # Mark self-reference truncation points uniformly as Object,
+                # hinting users to pass the whole JSON.
+                param_type = "Object"
+                type_name = recursive_type or "Object"
+                required = "Optional"
+                document = (document or "") + \
+                    ("\nNote: this field is a self-referencing type %s. "
+                     "--cli-unfold-argument only expands the first level. "
+                     "For deeper nesting, please use --cli-input-json to provide "
+                     "the full request as JSON. "
+                     "You can run the command with --generate-cli-skeleton to get a JSON template."
+                     % (recursive_type or ""))
 
             unfold_param[".".join(param)]["type"] = param_type
             unfold_param[".".join(param)]["type_name"] = type_name
             unfold_param[".".join(param)]["required"] = required
             unfold_param[".".join(param)]["document"] = document
+            # Stable fields: allow upper layers (e.g. command.py) to give a
+            # targeted hint when users drill into a self-referencing path and
+            # trigger "Unknown options", without parsing the document text.
+            if recursive_truncated:
+                unfold_param[".".join(param)]["recursive_truncated"] = True
+                unfold_param[".".join(param)]["recursive_type"] = recursive_type or ""
         return unfold_param
 
     def get_action_example_model(self, service, version, action):


### PR DESCRIPTION
Related TAPD: https://tapd.woa.com/tapd_fe/10161711/story/detail/1010161711126433671

Same fix as TencentCloud/tencentcloud-cli#122 (intl-en counterpart with English comments).

## Background
Some APIs (e.g. `billing/CreateGatherRule`, `billing/CreateAllocationRule`, `billing/ModifyAllocationRule`) declare **self-referencing** request types, typically `AllocationRuleExpression.Children: list<AllocationRuleExpression>`.

The current expansion logic in `tccli/loaders.py` (`_get_param_info`, `_generate_param_skeleton`, `_get_unfold_param_info`) walks the type graph **without any cycle detection or depth bound**, recursing forever and ending with `RecursionError`, which breaks:
- `tccli <svc> <action> help`
- `tccli <svc> <action> --generate-cli-skeleton`
- `tccli <svc> <action> --cli-unfold-argument ...`

## 优化内容
- `_get_param_info`: introduce path-level `visited` frozenset + `max_depth=20` fallback; on cycle hit, the node degenerates to a placeholder leaf (`members` becomes the type-name string/list).
- `_generate_param_skeleton`: same protection; emits `"RecursiveRef<TypeName>"` placeholder so users know to pass the field as a whole JSON via `--cli-input-json`.
- `_get_unfold_param_info` / `_recur_get_unfold_param_info`: same protection; registers current path as a leaf when a cycle is hit.
- `_filling_unfold_param_info`: detects truncated leaves (members is a placeholder string/list rather than dict), marks them `type=Object` and appends a JSON-input hint to the document.
- `visited` is **path-scoped** (`visited | {member}` derives a new frozenset on each descent), so sibling fields sharing the same plain struct are not mistakenly truncated.
- `tccli/document_handler.py` (`_json_format` / `_unfold_complex_object` / `_complex_object_doc`): adapt the new contract — when `members` is a type-name string (truncated placeholder) instead of a dict, render it as `<RecursiveRef:TypeName>` and stop recursion, so `help --detail` no longer raises `TypeError` on self-referencing APIs.
- `tccli/command.py` (`ActionCommand.__call__` / `_build_recursive_hint`): on `Unknown options` under `--cli-unfold-argument`, match the offending tokens against the recursive-truncated leaf prefixes registered by `_filling_unfold_param_info`, and append a targeted hint that points out the self-referencing type name and recommends `--<prefix> '<json>'` or `--cli-input-json` instead of a generic error.

## Compatibility
- Three-file change: `tccli/loaders.py` + `tccli/document_handler.py` + `tccli/command.py`.
- Code logic is **identical** to TencentCloud/tencentcloud-cli#122; the only difference is comments/strings localised to English (in line with the intl-en repo style).
- For non-recursive APIs (the vast majority), output is **byte-identical** before and after this patch.

Internal MR: https://git.woa.com/tencentcloud-internal/tencentcloud-cli/merge_requests/18
